### PR TITLE
Feature/config server setup

### DIFF
--- a/src/main/java/com/elara/app/config_service/ConfigServiceApplication.java
+++ b/src/main/java/com/elara/app/config_service/ConfigServiceApplication.java
@@ -2,8 +2,10 @@ package com.elara.app.config_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
 
 @SpringBootApplication
+@EnableConfigServer
 public class ConfigServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+# Spring Boot application configuration
+spring:
+  application:
+    name: config-service # The name of this Spring Boot application
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/elara-app/centralized-configuration.git # Git repository containing configuration files
+          clone-on-start: true # Clone the Git repository when the server starts
+# Server configuration
+server:
+  port: 8888 # Port number for the config server to listen on


### PR DESCRIPTION
This pull request sets up the project as a Spring Cloud Config Server, enabling centralized configuration management using a remote Git repository. The main changes include enabling the config server functionality and adding the necessary application configuration.

Spring Cloud Config Server Enablement:

* Added the `@EnableConfigServer` annotation to the `ConfigServiceApplication` class to activate Spring Cloud Config Server features.

Configuration Setup:

* Created a new `application.yml` file to configure the application as a config server, specifying the server port and the Git repository URI for centralized configuration files.